### PR TITLE
A bug fix and tweaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,75 +1,19 @@
 # C# SPSS SAV file reader and writer library
 
-[![Build Status](https://medella.visualstudio.com/Spss/_apis/build/status/Anderman.Medella.SPSS?branchName=master)](https://medella.visualstudio.com/Spss/_build/latest?definitionId=12&branchName=master)
 
-[![Nuget](https://img.shields.io/nuget/v/spsswriter)](https://www.nuget.org/packages/SpssReader/)
+This library enables to write SPSS data files (.sav). The library is UTF-8 safe.
 
-[![test](https://img.shields.io/azure-devops/tests/medella/spss/12)](https://medella.visualstudio.com/Spss/_build/results?buildId=514&view=ms.vss-test-web.build-test-results-tab)
-
-[![test](https://img.shields.io/azure-devops/coverage/medella/spss/12)](https://medella.visualstudio.com/Spss/_build/results?buildId=514&view=codecoverage-tab)
-
-[Demo](https://spssreader.azurewebsites.net/api/Read) Spss to json convertor.
-
-This library enables to read and write SPSS data files (.sav) on .net from and to a Stream. The library is UTF-8 safe.
-
-It is available as a nuget package at https://www.nuget.org/packages/SpssReader en https://www.nuget.org/packages/SpssWriter, and can be installed using the package manager or by issueing:
+It is available as a nuget package at  https://www.nuget.org/packages/manonz.SpssWriter, and can be installed using the package manager or by issuing:
 
 ```
-Install-Package SpssReader
-Install-Package SpssWriter
+Install-Package manonz.SpssCommon
+Install-Package manonz.SpssWriter
 ```
 
-It's a fork of [SPSS-.NET-Reader](https://github.com/fbiagi/SPSS-.NET-Reader) by fbiagi (based on [spsslib-80132](http://spsslib.codeplex.com/) by elmarj).
-Since forking there are a lot of bug fixing for utf8 support.
-Added :
-* string valuesLabels 
-* string missing.
-* BigEndian
-* Improved spssReader performance by 4000%
+It's a fork of https://github.com/Anderman/Medella.SPSS
+adding the ability to handle multiple-response variables.
 
-The libriary is refactored to a cleancode library
 
-### To read a data file:
-
-```C#
-    using var fileStream = new FileStream("TestFiles/test.sav", FileMode.Open);
-
-    var spssReader = new SpssReader(fileStream);
-
-    var rowReader = spssReader.RowReader;
-    foreach (var column in rowReader.Columns)
-    {
-        Console.WriteLine($"{column.Variable.Name}, {column.Variable.Label}");
-        if (column.Variable.ValueLabels != null)
-            Console.WriteLine(string.Join(",", column.Variable.ValueLabels.Select(x => $"{x.Key} - {x.Value} ")));
-        Console.WriteLine(string.Join(",", column.Variable.MissingValues));
-    }
-    while (rowReader.ReadRow())
-    {
-        foreach (var column in rowReader.Columns)
-        {
-            Console.WriteLine($"{column.Variable.Name}={column.GetValue()}");
-            // OR without boxing
-            switch (column.ColumnType)
-            {
-                case ColumnType.String:
-                    Console.WriteLine($"{column.Variable.Name}={column.GetString()}");
-                    break;
-                case ColumnType.Double:
-                    Console.WriteLine($"{column.Variable.Name}={column.GetDouble()}");
-                    break;
-                case ColumnType.Int:
-                    Console.WriteLine($"{column.Variable.Name}={column.GetInt()}");
-                    break;
-                case ColumnType.Date:
-                    Console.WriteLine($"{column.Variable.Name}={column.GetDate()}");
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
-    }
-```
 
 ### To write a data file:
 
@@ -122,3 +66,4 @@ If you find any bugs or have issues, please open an issue on GitHub.
 ## SAV file format
 
 Binary description of `*.sav` file format is available here: http://www.gnu.org/software/pspp/pspp-dev/html_node/System-File-Format.html.
+

--- a/Spss.Tests/Spss.Tests.csproj
+++ b/Spss.Tests/Spss.Tests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
 		<Nullable>enable</Nullable>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
@@ -27,7 +27,7 @@
       </None>
     </ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/SpssCommon/.editorconfig
+++ b/SpssCommon/.editorconfig
@@ -1,0 +1,16 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false

--- a/SpssCommon/SpssCommon.csproj
+++ b/SpssCommon/SpssCommon.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Nullable>enable</Nullable>
-		<TargetFrameworks>net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 	    <RootNamespace>Spss</RootNamespace>
         <PackageProjectUrl>https://github.com/Anderman/Medella.SPSS</PackageProjectUrl>
         <RepositoryUrl>https://github.com/Anderman/Medella.SPSS</RepositoryUrl>

--- a/SpssCommon/SpssCommon.csproj
+++ b/SpssCommon/SpssCommon.csproj
@@ -4,10 +4,21 @@
         <Nullable>enable</Nullable>
 		<TargetFrameworks>net8.0</TargetFrameworks>
 	    <RootNamespace>Spss</RootNamespace>
-        <PackageProjectUrl>https://github.com/Anderman/Medella.SPSS</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/Anderman/Medella.SPSS</RepositoryUrl>
-	    <Description>A cleancode library used by reading and writing spss .sav files</Description>
+        <PackageProjectUrl>https://github.com/manonz/SpssLib</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/manonz/SpssLib</RepositoryUrl>
+	    <Description>A cleancode library for writing spss .sav files. Medella.SPSS with multiple response additions. See https://github.com/Anderman/Medella.SPSS</Description>
 	    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+	    <PackageId>manonz.$(AssemblyName)</PackageId>
+	    <Product>manonz.$(AssemblyName)</Product>
+	    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+	    <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
     </PropertyGroup>
+
+    <ItemGroup>
+      <None Include="..\ReadMe.md">
+        <Pack>True</Pack>
+        <PackagePath>\</PackagePath>
+      </None>
+    </ItemGroup>
 
 </Project>

--- a/SpssCommon/SpssMetadata/Metadata.cs
+++ b/SpssCommon/SpssMetadata/Metadata.cs
@@ -37,6 +37,11 @@ public class Metadata
     public int Cases { get; set; }
 
     /// <summary>
+    ///      Dictionary index of the weighting variable plus 1. If none, 0.
+    /// </summary>
+    public int WeightIndex { get; set; }
+
+    /// <summary>
     ///     The encoding used to read/write the variable
     /// </summary>
     public int HeaderCodePage { get; set; }

--- a/SpssCommon/SpssMetadata/Metadata.cs
+++ b/SpssCommon/SpssMetadata/Metadata.cs
@@ -21,7 +21,13 @@ public class Metadata
         HeaderCodePage = Encoding.UTF8.CodePage;
         DataCodePage = Encoding.UTF8.CodePage;
         Variables = variables;
+        ProductName = "@(#) IBM SPSS STATISTICS MS Windows 25.0.0.0";
     }
+
+    /// <summary>
+    ///     Product identification string.
+    /// </summary>
+    public string ProductName { get; set; } = string.Empty;
 
     /// <summary>
     ///     A bias used for the compression of numerical values. By default set to 100.

--- a/SpssCommon/SpssMetadata/Variable.cs
+++ b/SpssCommon/SpssMetadata/Variable.cs
@@ -65,6 +65,11 @@ public abstract class Variable
     /// </summary>
     public MeasurementType MeasurementType { get; set; } = MeasurementType.Nominal;
 
+    /// <summary>
+    ///     Is this set as the  weighting variable?
+    /// </summary>
+    public bool IsWeight { get; set; } = false;
+
     public static Variable Create(string name, string? label, FormatType formatType, int spssWidth, int decimalPlaces)
     {
         if (formatType == FormatType.A) return new Variable<string>(name, spssWidth, decimalPlaces) { Label = label };

--- a/SpssReader/.editorconfig
+++ b/SpssReader/.editorconfig
@@ -1,0 +1,16 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false

--- a/SpssReader/SpssReader.csproj
+++ b/SpssReader/SpssReader.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Nullable>enable</Nullable>
-	<TargetFrameworks>net6.0</TargetFrameworks>
+	<TargetFrameworks>net8.0</TargetFrameworks>
         <RootNamespace>Spss</RootNamespace>
 	<PackageProjectUrl>https://github.com/Anderman/Medella.SPSS</PackageProjectUrl>
 	<RepositoryUrl>https://github.com/Anderman/Medella.SPSS</RepositoryUrl>

--- a/SpssWriter/.editorconfig
+++ b/SpssWriter/.editorconfig
@@ -1,0 +1,16 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false

--- a/SpssWriter/MetadataWriters/GenericMiscInformationRecord.cs
+++ b/SpssWriter/MetadataWriters/GenericMiscInformationRecord.cs
@@ -1,0 +1,12 @@
+namespace Spss.MetadataWriters;
+
+class GenericMiscInformationRecord
+{
+    public int Subtype { get; set; }
+
+    public int Size { get; set; }
+
+    public int Count { get; set; }
+
+    public byte[] Data { get; set; } = null!;
+}

--- a/SpssWriter/MetadataWriters/MetadataWriter.cs
+++ b/SpssWriter/MetadataWriters/MetadataWriter.cs
@@ -60,9 +60,10 @@ public class MetadataWriter
 
             if (variable.ValueLength > 32767) variable.ValueLength = 32767;
 
-            if (variable.ValueLabels == null) return;
-
-            foreach (var label in variable.ValueLabels) variable.ValueLabels[label.Key] = TrimMaxLength(label.Value, 120)!;
+            if (variable.ValueLabels != null)
+            {
+                foreach (var label in variable.ValueLabels) variable.ValueLabels[label.Key] = TrimMaxLength(label.Value, 120)!;
+            }
         }
     }
 

--- a/SpssWriter/MetadataWriters/RecordWriters/RecordTypeInfoWriter.cs
+++ b/SpssWriter/MetadataWriters/RecordWriters/RecordTypeInfoWriter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -74,6 +75,13 @@ public class RecordTypeInfoWriter
         _writer.Write(subtype);
         _writer.Write(itemSize);
         _writer.Write(itemCount);
+    }
+
+    public void WriteGenericInfoRecord(int subtype, int itemSize, int itemCount, byte[] data)
+    {
+        WriteInfoHeader(subtype, itemSize, itemCount);
+        Debug.Assert(data.Length == itemSize * itemCount);
+        _writer.Write(data);
     }
 
     public void WriteValueLabelStringRecords(List<VariableWrapper> records)

--- a/SpssWriter/MetadataWriters/RecordWriters/RecordTypeWriter.cs
+++ b/SpssWriter/MetadataWriters/RecordWriters/RecordTypeWriter.cs
@@ -34,7 +34,7 @@ public class RecordTypeWriter
     {
         var count = variablesCount.Select(x => SpssMath.GetNumberOf32ByteBlocks(x.ValueLength)).Aggregate((result, blocks) => result + blocks);
         _writer.Write((int)RecordType.HeaderRecord2);
-        _writer.Write(_encoding.GetPaddedValueAsByteArray("@(#) IBM SPSS STATISTICS MS Windows 25.0.0.0", 60));
+        _writer.Write(_encoding.GetPaddedValueAsByteArray(metadata.ProductName, 60));
         _writer.Write(2); // LayoutCode
         _writer.Write(count);
         _writer.Write(1); // compressed

--- a/SpssWriter/MetadataWriters/RecordWriters/RecordTypeWriter.cs
+++ b/SpssWriter/MetadataWriters/RecordWriters/RecordTypeWriter.cs
@@ -38,7 +38,7 @@ public class RecordTypeWriter
         _writer.Write(2); // LayoutCode
         _writer.Write(count);
         _writer.Write(1); // compressed
-        _writer.Write(0); // WeightIndex
+        _writer.Write(metadata.WeightIndex);
         _writer.Write(metadata.Cases);
         _writer.Write((double)metadata.Bias);
         _writer.Write(DateTime.Now.ToString("dd MMM yyHH:mm:ss", _invariantCultureDateTimeFormat).ToCharArray());

--- a/SpssWriter/Models/VariableWrapper.cs
+++ b/SpssWriter/Models/VariableWrapper.cs
@@ -44,7 +44,7 @@ public class VariableWrapper
 
     internal Dictionary<object, string>? ValueLabels => _variable.ValueLabels;
     internal byte[] ShortName8Bytes { get; set; } = null!;
-    internal string ShortName { get; set; } = null!;
+    public string ShortName { get; internal set; } = null!;
     internal List<byte[]> GhostNames { get; } = new();
     internal int LastGhostVariableLength { get; set; }
 }

--- a/SpssWriter/SpssWriter.cs
+++ b/SpssWriter/SpssWriter.cs
@@ -59,6 +59,8 @@ public class SpssWriter : IDisposable
     {
         MetadataWriter.Write();
         DataWriter.Write();
+        DataWriter.Flush();
+        _writer.Flush();
         ((IDisposable)_writer).Dispose();
     }
 }

--- a/SpssWriter/SpssWriter.cs
+++ b/SpssWriter/SpssWriter.cs
@@ -55,7 +55,7 @@ public class SpssWriter : IDisposable
         ((IDisposable)writer).Dispose();
     }
 
-    public void Write(SpssData spssData, Stream stream)
+    public void Write()
     {
         MetadataWriter.Write();
         DataWriter.Write();

--- a/SpssWriter/SpssWriter.cs
+++ b/SpssWriter/SpssWriter.cs
@@ -54,4 +54,11 @@ public class SpssWriter : IDisposable
         writer.DataWriter.Write();
         ((IDisposable)writer).Dispose();
     }
+
+    public void Write(SpssData spssData, Stream stream)
+    {
+        MetadataWriter.Write();
+        DataWriter.Write();
+        ((IDisposable)writer).Dispose();
+    }
 }

--- a/SpssWriter/SpssWriter.cs
+++ b/SpssWriter/SpssWriter.cs
@@ -59,6 +59,6 @@ public class SpssWriter : IDisposable
     {
         MetadataWriter.Write();
         DataWriter.Write();
-        ((IDisposable)writer).Dispose();
+        ((IDisposable)_writer).Dispose();
     }
 }

--- a/SpssWriter/SpssWriter.csproj
+++ b/SpssWriter/SpssWriter.csproj
@@ -4,12 +4,26 @@
 		<Nullable>enable</Nullable>
 		<TargetFrameworks>net8.0</TargetFrameworks>
 		<RootNamespace>Spss</RootNamespace>
-		<PackageProjectUrl>https://github.com/Anderman/Medella.SPSS</PackageProjectUrl>
-		<RepositoryUrl>https://github.com/Anderman/Medella.SPSS</RepositoryUrl>
-		<Description>A cleancode library for writing spss .sav files</Description>
+		<PackageProjectUrl>https://github.com/manonz/SpssLib</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/manonz/SpssLib</RepositoryUrl>
+		<Description>A cleancode library for writing spss .sav files. Medella.SPSS with multiple response additions. See https://github.com/Anderman/Medella.SPSS</Description>
 		<PackageTags>sav; spss; spsslib;</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	</PropertyGroup>
+		<Title>Medella.SPSS writer lib with multiple response additions.</Title>
+		<PackageReadmeFile>ReadMe.md</PackageReadmeFile>
+		<PackageId>manonz.$(AssemblyName)</PackageId>
+		<Product>manonz.$(AssemblyName)</Product>
+      <AssemblyVersion>1.0.2</AssemblyVersion>
+      <FileVersion>$(AssemblyVersion)</FileVersion>
+      <Version>$(AssemblyVersion)</Version>
+   </PropertyGroup>
+
+	<ItemGroup>
+	  <None Include="..\ReadMe.md">
+	    <Pack>True</Pack>
+	    <PackagePath>\</PackagePath>
+	  </None>
+	</ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\SpssCommon\SpssCommon.csproj" />

--- a/SpssWriter/SpssWriter.csproj
+++ b/SpssWriter/SpssWriter.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 		<RootNamespace>Spss</RootNamespace>
 		<PackageProjectUrl>https://github.com/Anderman/Medella.SPSS</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/Anderman/Medella.SPSS</RepositoryUrl>


### PR DESCRIPTION
Fixed bug in ValidateVariables: The value labels were not trimmed after seeing the first variable that had no value labels. A "return" instead of "continue" was used.

Added ability to have generic miscellaneous info records so that one can add multiple response datasets via a shim. To this end, added some additional properties as well as exposed a few that already existed.

Added ability to have a WeightIndex and the ability to change ProductName if required.

Please review when time permits and it will be good if you could merge the changes upstream.

Thank you for sharing this library.

